### PR TITLE
feat: single port for all stalls via Caddy reverse proxy (#5)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,78 +1,72 @@
 # clidestable — single port reverse proxy
 # Caddy on :7690 routes dashboard/API to Flask and stall terminals to ttyd.
-# Each stall's ttyd listens on 770N with --base-path /stall/{name}/.
-# Caddy matches /stall/* and proxies to the Flask backend, which redirects
-# to the ttyd iframe. The iframe connects directly via WebSocket on the
-# internal network — but from the outside, only port 7690 is exposed.
 
 {
 	auto_https off
-	admin 127.0.0.1:2019
+	admin off
 }
 
 :7690 {
-	# ttyd stall WebSocket + HTTP — ports 7701-7720
-	# These handle_path blocks strip nothing — ttyd expects the full path.
-	# Caddy proxies the WebSocket upgrade transparently.
-	@stall1 path /stall/1/* /stall/1
-	handle @stall1 { reverse_proxy localhost:7701 }
-
-	@stall2 path /stall/2/* /stall/2
-	handle @stall2 { reverse_proxy localhost:7702 }
-
-	@stall3 path /stall/3/* /stall/3
-	handle @stall3 { reverse_proxy localhost:7703 }
-
-	@stall4 path /stall/4/* /stall/4
-	handle @stall4 { reverse_proxy localhost:7704 }
-
-	@stall5 path /stall/5/* /stall/5
-	handle @stall5 { reverse_proxy localhost:7705 }
-
-	@stall6 path /stall/6/* /stall/6
-	handle @stall6 { reverse_proxy localhost:7706 }
-
-	@stall7 path /stall/7/* /stall/7
-	handle @stall7 { reverse_proxy localhost:7707 }
-
-	@stall8 path /stall/8/* /stall/8
-	handle @stall8 { reverse_proxy localhost:7708 }
-
-	@stall9 path /stall/9/* /stall/9
-	handle @stall9 { reverse_proxy localhost:7709 }
-
-	@stall10 path /stall/10/* /stall/10
-	handle @stall10 { reverse_proxy localhost:7710 }
-
-	@stall11 path /stall/11/* /stall/11
-	handle @stall11 { reverse_proxy localhost:7711 }
-
-	@stall12 path /stall/12/* /stall/12
-	handle @stall12 { reverse_proxy localhost:7712 }
-
-	@stall13 path /stall/13/* /stall/13
-	handle @stall13 { reverse_proxy localhost:7713 }
-
-	@stall14 path /stall/14/* /stall/14
-	handle @stall14 { reverse_proxy localhost:7714 }
-
-	@stall15 path /stall/15/* /stall/15
-	handle @stall15 { reverse_proxy localhost:7715 }
-
-	@stall16 path /stall/16/* /stall/16
-	handle @stall16 { reverse_proxy localhost:7716 }
-
-	@stall17 path /stall/17/* /stall/17
-	handle @stall17 { reverse_proxy localhost:7717 }
-
-	@stall18 path /stall/18/* /stall/18
-	handle @stall18 { reverse_proxy localhost:7718 }
-
-	@stall19 path /stall/19/* /stall/19
-	handle @stall19 { reverse_proxy localhost:7719 }
-
-	@stall20 path /stall/20/* /stall/20
-	handle @stall20 { reverse_proxy localhost:7720 }
+	handle /stall/1/* {
+		reverse_proxy localhost:7701
+	}
+	handle /stall/2/* {
+		reverse_proxy localhost:7702
+	}
+	handle /stall/3/* {
+		reverse_proxy localhost:7703
+	}
+	handle /stall/4/* {
+		reverse_proxy localhost:7704
+	}
+	handle /stall/5/* {
+		reverse_proxy localhost:7705
+	}
+	handle /stall/6/* {
+		reverse_proxy localhost:7706
+	}
+	handle /stall/7/* {
+		reverse_proxy localhost:7707
+	}
+	handle /stall/8/* {
+		reverse_proxy localhost:7708
+	}
+	handle /stall/9/* {
+		reverse_proxy localhost:7709
+	}
+	handle /stall/10/* {
+		reverse_proxy localhost:7710
+	}
+	handle /stall/11/* {
+		reverse_proxy localhost:7711
+	}
+	handle /stall/12/* {
+		reverse_proxy localhost:7712
+	}
+	handle /stall/13/* {
+		reverse_proxy localhost:7713
+	}
+	handle /stall/14/* {
+		reverse_proxy localhost:7714
+	}
+	handle /stall/15/* {
+		reverse_proxy localhost:7715
+	}
+	handle /stall/16/* {
+		reverse_proxy localhost:7716
+	}
+	handle /stall/17/* {
+		reverse_proxy localhost:7717
+	}
+	handle /stall/18/* {
+		reverse_proxy localhost:7718
+	}
+	handle /stall/19/* {
+		reverse_proxy localhost:7719
+	}
+	handle /stall/20/* {
+		reverse_proxy localhost:7720
+	}
 
 	# Everything else — Flask dashboard + API
 	handle {

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,81 @@
+# clidestable — single port reverse proxy
+# Caddy on :7690 routes dashboard/API to Flask and stall terminals to ttyd.
+# Each stall's ttyd listens on 770N with --base-path /stall/{name}/.
+# Caddy matches /stall/* and proxies to the Flask backend, which redirects
+# to the ttyd iframe. The iframe connects directly via WebSocket on the
+# internal network — but from the outside, only port 7690 is exposed.
+
+{
+	auto_https off
+	admin 127.0.0.1:2019
+}
+
+:7690 {
+	# ttyd stall WebSocket + HTTP — ports 7701-7720
+	# These handle_path blocks strip nothing — ttyd expects the full path.
+	# Caddy proxies the WebSocket upgrade transparently.
+	@stall1 path /stall/1/* /stall/1
+	handle @stall1 { reverse_proxy localhost:7701 }
+
+	@stall2 path /stall/2/* /stall/2
+	handle @stall2 { reverse_proxy localhost:7702 }
+
+	@stall3 path /stall/3/* /stall/3
+	handle @stall3 { reverse_proxy localhost:7703 }
+
+	@stall4 path /stall/4/* /stall/4
+	handle @stall4 { reverse_proxy localhost:7704 }
+
+	@stall5 path /stall/5/* /stall/5
+	handle @stall5 { reverse_proxy localhost:7705 }
+
+	@stall6 path /stall/6/* /stall/6
+	handle @stall6 { reverse_proxy localhost:7706 }
+
+	@stall7 path /stall/7/* /stall/7
+	handle @stall7 { reverse_proxy localhost:7707 }
+
+	@stall8 path /stall/8/* /stall/8
+	handle @stall8 { reverse_proxy localhost:7708 }
+
+	@stall9 path /stall/9/* /stall/9
+	handle @stall9 { reverse_proxy localhost:7709 }
+
+	@stall10 path /stall/10/* /stall/10
+	handle @stall10 { reverse_proxy localhost:7710 }
+
+	@stall11 path /stall/11/* /stall/11
+	handle @stall11 { reverse_proxy localhost:7711 }
+
+	@stall12 path /stall/12/* /stall/12
+	handle @stall12 { reverse_proxy localhost:7712 }
+
+	@stall13 path /stall/13/* /stall/13
+	handle @stall13 { reverse_proxy localhost:7713 }
+
+	@stall14 path /stall/14/* /stall/14
+	handle @stall14 { reverse_proxy localhost:7714 }
+
+	@stall15 path /stall/15/* /stall/15
+	handle @stall15 { reverse_proxy localhost:7715 }
+
+	@stall16 path /stall/16/* /stall/16
+	handle @stall16 { reverse_proxy localhost:7716 }
+
+	@stall17 path /stall/17/* /stall/17
+	handle @stall17 { reverse_proxy localhost:7717 }
+
+	@stall18 path /stall/18/* /stall/18
+	handle @stall18 { reverse_proxy localhost:7718 }
+
+	@stall19 path /stall/19/* /stall/19
+	handle @stall19 { reverse_proxy localhost:7719 }
+
+	@stall20 path /stall/20/* /stall/20
+	handle @stall20 { reverse_proxy localhost:7720 }
+
+	# Everything else — Flask dashboard + API
+	handle {
+		reverse_proxy localhost:7691
+	}
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.12-slim
 
-# Install ttyd (binary from GitHub releases) + shell tools
+# Install ttyd (binary from GitHub releases) + Caddy + shell tools
 ARG TTYD_VERSION=1.7.7
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash tmux git curl ca-certificates \
+    bash tmux git curl ca-certificates debian-keyring debian-archive-keyring apt-transport-https \
     && curl -fsSL -o /usr/local/bin/ttyd \
        "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" \
     && chmod +x /usr/local/bin/ttyd \
+    && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg \
+    && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' > /etc/apt/sources.list.d/caddy-stable.list \
+    && apt-get update && apt-get install -y --no-install-recommends caddy \
     && apt-get purge -y curl && apt-get autoremove -y \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -15,11 +18,14 @@ WORKDIR /app
 COPY pyproject.toml .
 COPY clidestable/ clidestable/
 COPY templates/ templates/
-RUN pip install --no-cache-dir .
+COPY Caddyfile .
+COPY entrypoint.sh .
+RUN pip install --no-cache-dir . && chmod +x entrypoint.sh
 
-EXPOSE 7690 7701-7720
+# Single external port — Caddy routes everything
+EXPOSE 7690
 
 # Log dir + stall working dir
 VOLUME ["/data"]
 
-CMD ["clidestable", "serve", "--port", "7690", "--log-dir", "/data"]
+CMD ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 FROM python:3.12-slim
 
-# Install ttyd (binary from GitHub releases) + Caddy + shell tools
+# Install ttyd + Caddy (both as static binaries) + shell tools
 ARG TTYD_VERSION=1.7.7
+ARG CADDY_VERSION=2.9.1
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash tmux git curl ca-certificates debian-keyring debian-archive-keyring apt-transport-https \
+    bash tmux git curl ca-certificates \
     && curl -fsSL -o /usr/local/bin/ttyd \
        "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" \
     && chmod +x /usr/local/bin/ttyd \
-    && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg \
-    && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' > /etc/apt/sources.list.d/caddy-stable.list \
-    && apt-get update && apt-get install -y --no-install-recommends caddy \
+    && curl -fsSL "https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_linux_amd64.tar.gz" \
+       | tar -xz -C /usr/local/bin caddy \
+    && chmod +x /usr/local/bin/caddy \
     && apt-get purge -y curl && apt-get autoremove -y \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/clidestable/stall.py
+++ b/clidestable/stall.py
@@ -22,6 +22,7 @@ class Stall:
 
     name: str
     port: int
+    slot: int = 0  # 1-based slot number for path routing
     pid: Optional[int] = None
     log_path: Optional[Path] = None
 
@@ -36,10 +37,17 @@ class Stall:
         except (OSError, ProcessLookupError):
             return False
 
+    @property
+    def base_path(self) -> str:
+        """URL base path for this stall (e.g. /stall/1/)."""
+        return f"/stall/{self.slot}/"
+
     def to_dict(self) -> dict:
         return {
             "name": self.name,
             "port": self.port,
+            "slot": self.slot,
+            "base_path": self.base_path,
             "pid": self.pid,
             "alive": self.alive,
             "log_path": str(self.log_path) if self.log_path else None,
@@ -86,19 +94,22 @@ class StallManager:
             del self._stalls[name]
 
         port = self._allocate_port()
+        slot = port - self._base_port + 1  # port 7701 → slot 1
         log_path = self._log_dir / f".sdale-{name}.log"
+        base_path = f"/stall/{slot}/"
 
         # Ensure log file exists
         log_path.touch(exist_ok=True)
 
         # Start ttyd tailing the activity log — shows agent commands in real time
+        # Uses slot-based base path so Caddy can route via single port
         try:
             proc = subprocess.Popen(
                 [
                     "ttyd",
                     "--port", str(port),
                     "--readonly",
-                    "--base-path", f"/stall/{name}/",
+                    "--base-path", base_path,
                     "bash", "-c",
                     f"echo '🐴 stall: {name} — watching agent activity'; "
                     f"echo '   log: {log_path}'; echo ''; "
@@ -109,13 +120,13 @@ class StallManager:
                 start_new_session=True,
             )
             pid = proc.pid
-            logger.info("Started stall '%s' on port %d (pid %d)", name, port, pid)
+            logger.info("Started stall '%s' on port %d (slot %d, pid %d)", name, port, slot, pid)
         except FileNotFoundError:
             raise RuntimeError(
                 "ttyd not found. Install it: apt install ttyd (or see https://github.com/tsl0922/ttyd)"
             )
 
-        stall = Stall(name=name, port=port, pid=pid, log_path=log_path)
+        stall = Stall(name=name, port=port, slot=slot, pid=pid, log_path=log_path)
         self._stalls[name] = stall
         return stall
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,8 @@ services:
     container_name: clidestable
     restart: unless-stopped
     ports:
+      # Single port — Caddy routes dashboard + all stall terminals
       - "${STABLE_BIND:-0.0.0.0}:${STABLE_PORT:-7690}:7690"
-      # ttyd stall ports (20 stalls max)
-      - "${STABLE_BIND:-0.0.0.0}:7701-7720:7701-7720"
     volumes:
       # Shared with clidesdale agent logs
       - ${STABLE_DATA_DIR:-/opt/stacks}:/data

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Start Flask on internal port 7691 (Caddy proxies from 7690)
+echo "clidestable: starting Flask on :7691"
+clidestable serve --port 7691 --log-dir /data &
+FLASK_PID=$!
+
+# Give Flask a moment to start
+sleep 1
+
+# Start Caddy as the single external proxy on :7690
+echo "clidestable: starting Caddy proxy on :7690"
+caddy run --config /app/Caddyfile &
+CADDY_PID=$!
+
+echo "clidestable: ready — dashboard + stalls on :7690"
+
+# Wait for either process to exit
+wait -n $FLASK_PID $CADDY_PID
+EXIT_CODE=$?
+echo "clidestable: process exited ($EXIT_CODE), shutting down"
+kill $FLASK_PID $CADDY_PID 2>/dev/null
+exit $EXIT_CODE

--- a/templates/split.html
+++ b/templates/split.html
@@ -59,7 +59,7 @@
                 <span class="tab" onclick="showTab('{{ s.name }}','log')">Log</span>
             </div>
             <div class="panel-body">
-                <iframe id="term-{{ s.name }}" src="http://{{ request.host.split(':')[0] }}:{{ s.port }}/stall/{{ s.name }}/"></iframe>
+                <iframe id="term-{{ s.name }}" src="/stall/{{ s.slot }}/"></iframe>
                 <pre id="log-{{ s.name }}" style="display:none;">Loading...</pre>
             </div>
         </div>

--- a/templates/stall.html
+++ b/templates/stall.html
@@ -23,6 +23,6 @@
         <span style="color:#888;">port {{ stall.port }}</span>
         <a href="/log/{{ stall.name }}">log</a>
     </div>
-    <iframe src="http://{{ request.host.split(':')[0] }}:{{ stall.port }}/stall/{{ stall.name }}/"></iframe>
+    <iframe src="/stall/{{ stall.slot }}/"></iframe>
 </body>
 </html>


### PR DESCRIPTION
## Summary
All stall terminals now accessible through a single port (7690) via path prefix routing. No more 20 exposed ports.

- **Caddy** added as internal reverse proxy on :7690
- Routes `/stall/N/` → ttyd on port 770N (WebSocket + HTTP)
- Flask dashboard on internal :7691
- Stalls use numbered slots (1-20) for predictable Caddy routing
- docker-compose only exposes port 7690
- Templates use relative paths (`/stall/{slot}/`) — no more direct port iframes

Closes #5

## Test plan
- [ ] Build: `docker compose build`
- [ ] Start: `docker compose up -d`
- [ ] Dashboard accessible at :7690
- [ ] Create stall via API: `curl -X POST -H 'Content-Type: application/json' -d '{"name":"test"}' http://localhost:7690/api/stalls`
- [ ] Stall terminal accessible at :7690/stall/1/
- [ ] WebSocket connection works through Caddy proxy
- [ ] Split view iframes use single port

🤖 Generated with [Claude Code](https://claude.com/claude-code)